### PR TITLE
fix error when pip install requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask
-flask_socketio
-flask_cors
-revpimodio2
+Flask==1.1.1
+Flask-Cors==3.0.8
+Flask-SocketIO==4.3.1
+revpimodio2==2.5.1


### PR DESCRIPTION
python3 -m pip install requirements.txt 명령어 실행 시 version 오류 발생.
버전을 명시함.